### PR TITLE
bazel run

### DIFF
--- a/autoload/bob.vim
+++ b/autoload/bob.vim
@@ -4,7 +4,6 @@ vim9script
 #
 # File: bob.vim
 # Author: @igbanam, https://github.com/igbanam
-# Last Modified: Tuesday, 2nd March 2023
 #
 # License:   Permission is hereby granted to use and distribute this code,
 #            with or without modifications, provided that this copyright

--- a/autoload/bob.vim
+++ b/autoload/bob.vim
@@ -39,7 +39,7 @@ export def Build(focus: string)
 
   var targets = focus->FindTargets()
 
-  targets->BuildWithSelectionStrategy(utils.SelectionStrategy())
+  targets->WithSelectionStrategy(utils.SelectionStrategy(), ExecuteBuild)
 enddef
 
 export def Run(focus: string)
@@ -60,17 +60,17 @@ def FindTargets(focus: string): list<string>
   return targets
 enddef
 
-def BuildWithSelectionStrategy(targets: list<string>, selection_strategy: number)
+def WithSelectionStrategy(targets: list<string>, selection_strategy: number, To_Execute: func(string))
   if selection_strategy == 0
-    targets->BuildInteractive(ExecuteBuild)
+    targets->Interactive(To_Execute)
   elseif selection_strategy == 1
-    targets->BuildFirst(ExecuteBuild)
+    targets->First(To_Execute)
   else
     echom "BoB says: g:bob_build_only_target should be 0 or 1"
   endif
 enddef
 
-def BuildInteractive(targets: list<string>, To_Execute: func(string))
+def Interactive(targets: list<string>, To_Execute: func(string))
   if exists('g:loaded_fzf')
     call fzf#run({
       source: targets,
@@ -106,7 +106,7 @@ def BuildInteractive(targets: list<string>, To_Execute: func(string))
   endif
 enddef
 
-def BuildFirst(targets: list<string>, To_Executor: func(string))
+def First(targets: list<string>, To_Executor: func(string))
   targets[0]->To_Executor()
 enddef
 

--- a/autoload/bob.vim
+++ b/autoload/bob.vim
@@ -26,6 +26,7 @@ const BUILD_COMMAND = ':Dispatch bazel build '
 
 var garbage = [
   'Starting local Bazel server',
+  'Extracting Bazel installation...',
   'checking cached actions',
   'Loading:'
 ]

--- a/autoload/bob.vim
+++ b/autoload/bob.vim
@@ -23,6 +23,7 @@ import autoload 'utils.vim'
 
 const SELECTION_TITLE = '[bob.vim] Select a build target'
 const BUILD_COMMAND = ':Dispatch bazel build '
+const RUN_COMMAND = ':Dispatch bazel run '
 
 var garbage = [
   'Starting local Bazel server',
@@ -50,6 +51,7 @@ export def Run(focus: string)
 
   var targets = focus->FindTargets()
 
+  targets->WithSelectionStrategy(utils.SelectionStrategy(), ExecuteRun)
 enddef
 
 def FindTargets(focus: string): list<string>
@@ -112,6 +114,10 @@ enddef
 
 def ExecuteBuild(target: string)
   execute BUILD_COMMAND .. target
+enddef
+
+def ExecuteRun(target: string)
+  execute RUN_COMMAND .. target
 enddef
 
 def StartsWith(longer: string, shorter: string): bool

--- a/autoload/bob.vim
+++ b/autoload/bob.vim
@@ -31,14 +31,6 @@ var garbage = [
   'Loading:'
 ]
 
-def FindTargets(focus: string): list<string>
-  var targets = system('bazel query //' .. focus .. '/...')->split('\n')
-  for _g in garbage
-    targets->filter((i, v) => !v->trim()->StartsWith(_g))
-  endfor
-  return targets
-enddef
-
 export def Build(focus: string)
   if !focus->utils.IsBazelProject()
     echom "BoB says: This is not a Bazel project"
@@ -48,6 +40,24 @@ export def Build(focus: string)
   var targets = focus->FindTargets()
 
   targets->BuildWithSelectionStrategy(utils.SelectionStrategy())
+enddef
+
+export def Run(focus: string)
+  if !focus->utils.IsBazelProject()
+    echom "BoB says: This is not a Bazel project"
+    return
+  endif
+
+  var targets = focus->FindTargets()
+
+enddef
+
+def FindTargets(focus: string): list<string>
+  var targets = system('bazel query //' .. focus .. '/...')->split('\n')
+  for _g in garbage
+    targets->filter((i, v) => !v->trim()->StartsWith(_g))
+  endfor
+  return targets
 enddef
 
 def BuildWithSelectionStrategy(targets: list<string>, selection_strategy: number)

--- a/autoload/bob.vim
+++ b/autoload/bob.vim
@@ -62,15 +62,15 @@ enddef
 
 def BuildWithSelectionStrategy(targets: list<string>, selection_strategy: number)
   if selection_strategy == 0
-    targets->BuildInteractive()
+    targets->BuildInteractive(ExecuteBuild)
   elseif selection_strategy == 1
-    targets->BuildFirst()
+    targets->BuildFirst(ExecuteBuild)
   else
     echom "BoB says: g:bob_build_only_target should be 0 or 1"
   endif
 enddef
 
-def BuildInteractive(targets: list<string>)
+def BuildInteractive(targets: list<string>, To_Execute: func(string))
   if exists('g:loaded_fzf')
     call fzf#run({
       source: targets,
@@ -80,7 +80,7 @@ def BuildInteractive(targets: list<string>)
       },
       options: '--border-label="┤ ' .. SELECTION_TITLE .. ' ├"',
       sink: (chosen) => {
-        execute BUILD_COMMAND .. chosen
+        chosen->To_Execute()
       }
     })
   else
@@ -98,15 +98,20 @@ def BuildInteractive(targets: list<string>)
     borderchars: ['─', '│', '─', '│', '╭', '╮', '╯', '╰'],
     callback: (_, chosen: number) => {
       if chosen > 0
-        execute BUILD_COMMAND .. targets[chosen - 1]
+        targets[chosen - 1]->To_Execute()
+        # execute BUILD_COMMAND .. targets[chosen - 1]
       endif
     },
   })
   endif
 enddef
 
-def BuildFirst(targets: list<string>)
-  execute BUILD_COMMAND .. targets[0]
+def BuildFirst(targets: list<string>, To_Executor: func(string))
+  targets[0]->To_Executor()
+enddef
+
+def ExecuteBuild(target: string)
+  execute BUILD_COMMAND .. target
 enddef
 
 def StartsWith(longer: string, shorter: string): bool

--- a/plugin/bob.vim
+++ b/plugin/bob.vim
@@ -4,7 +4,6 @@ vim9script noclear
 #
 # File: bob.vim
 # Author: @igbanam, https://github.com/igbanam
-# Last Modified: Tuesday, 2nd March 2023
 #
 # License:   Permission is hereby granted to use and distribute this code,
 #            with or without modifications, provided that this copyright

--- a/plugin/bob.vim
+++ b/plugin/bob.vim
@@ -33,3 +33,15 @@ noremap <SID>BuildNearest :call <SID>bob.Build(expand("%:h"))<cr>
 if !exists(":BobBuild")
   command -nargs=1  BobBuild  :call bob.Build(<q-args>)
 endif
+
+if !hasmapto('<Plug>RunNearest;')
+  map <unique> <leader>br <Plug>BobRunNearest;
+endif
+
+noremap <unique> <script> <Plug>BobRunNearest; <SID>RunNearest
+noremenu <script> Plugin.Run\ Nearest          <SID>RunNearest
+noremap <SID>RunNearest :call <SID>bob.Run(expand("%:h"))<cr>
+
+if !exists(":BobRun")
+  command -nargs=1  BobRun  :call bob.Run(<q-args>)
+endif


### PR DESCRIPTION
- No need to manually update mtime
- More garbage lines
- Add Run entrypoint
- Refactor Build to pass in FuncRef
- Decouple "build" from building process
- Wire up Run
