### PR TITLE
Make dependencies explicit

### DIFF
--- a/plugin/bob.vim
+++ b/plugin/bob.vim
@@ -20,6 +20,18 @@ if exists("g:loaded_bob")
 endif
 g:loaded_bob = 1
 
+const REQUIRED = {
+  'dispatch': 'tpope/vim-dispatch',
+  'fzf': 'junegunn/fzf',
+}
+
+for [key, repo] in REQUIRED->items()
+  if (!exists('g:loaded_' .. key))
+    echom '[bob.vim] requires ' .. repo
+    finish
+  endif
+endfor
+
 import autoload 'bob.vim'
 
 if !hasmapto('<Plug>BuildNearest;')


### PR DESCRIPTION
Now, most people creating Vim plugins are creating bespoke plugins for
their workflow. I don't seem to have that time. If there are plugins
which already do what I need, best to pull them in and leverage on their
genius.

Moving forward, this could be a practice for all Vim plugins. Some
nodejs-esque "dependencies" section in the plugin. We may be a long way
out from having this supported in any plugin manager, let alone Vim
native, but I think it's a good practice to have.
